### PR TITLE
Ignore TurtleCount button

### DIFF
--- a/MBB.lua
+++ b/MBB.lua
@@ -77,7 +77,8 @@ MBB_Ignore = {
 	[19] = "TimeManagerClockButton",
 	[20] = "pfMiniMapPin",
 	[21] = "Clock",
-	[22] = "Timer"
+	[22] = "Timer",
+	[23] = "TurtleCount"
 };
 
 MBB_IgnoreSize = {


### PR DESCRIPTION
While using https://github.com/GryllsAddons/TurtleCount it would show like:
![image](https://github.com/McPewPew/MinimapButtonBag-TurtleWoW/assets/2750503/352d4ec5-46ba-4c87-9d0d-c95460dc6ab0)
Which really doesnt look good.

I also tested it by adding it to `MBB_IgnoreSize`, and that would show like 
![image](https://github.com/McPewPew/MinimapButtonBag-TurtleWoW/assets/2750503/ee1f16fe-5cf0-42ba-8a44-15a552d2e94c)

But I think it make sense to just keep it out of the menu.
Thoughts?