### PR TITLE
Use the PLAYER_LOGIN event to hide most icons instantly

### DIFF
--- a/MBB.lua
+++ b/MBB.lua
@@ -128,13 +128,10 @@ MBB_CallBack = {
 	end
 }
 
-
-_rescanned = false;
-_starttime = GetTime();
-
 function MBB_OnLoad()
 	this:RegisterEvent("VARIABLES_LOADED");
 	this:RegisterEvent("ADDON_LOADED");
+	this:RegisterEvent("PLAYER_LOGIN");
 	SLASH_MBB1 = "/mbb";
 	SlashCmdList["MBB"] = MBB_SlashHandler;
 end
@@ -246,6 +243,10 @@ function MBB_OnEvent()
 		if ( MBB_Options == nil or MBB_Options["Version"] ~= MBB_Version)  then
 			MBB_Options = CloneTable(MBB_DefaultOptions)
 		end
+	end
+	if(event == "PLAYER_LOGIN") then
+		MBB_GatherIcons();
+		MBB_SetButtonPosition();
 	end
 end
 
@@ -637,14 +638,6 @@ function MBB_HideButtons()
 end
 
 function MBB_OnUpdate(elapsed)
-	
-	if (not _rescanned and (GetTime() - _starttime) > 5) then
-			_rescanned = true;
-			MBB_GatherIcons();
-			MBB_SetButtonPosition();
-			return;	
-		end;
-	
 	if( MBB_DragFlag == 1 and MBB_Options.AttachToMinimap == 1 ) then
 		local xpos,ypos = GetCursorPosition();
 		local xmin,ymin,xm,ym = Minimap:GetLeft(), Minimap:GetBottom(), Minimap:GetRight(), Minimap:GetTop();

--- a/MBB.lua
+++ b/MBB.lua
@@ -128,6 +128,10 @@ MBB_CallBack = {
 	end
 }
 
+
+_rescanned = false;
+_starttime = GetTime();
+
 function MBB_OnLoad()
 	this:RegisterEvent("VARIABLES_LOADED");
 	this:RegisterEvent("ADDON_LOADED");
@@ -250,6 +254,8 @@ function MBB_OnEvent()
 	end
 end
 
+local alreadyGathered = {}
+
 function MBB_GatherIcons()
 	local children = {Minimap:GetChildren()};
 	local additional = {MinimapBackdrop:GetChildren()};
@@ -281,6 +287,10 @@ function MBB_GatherIcons()
 			end
 		end
 --McPewPew
+			if alreadyGathered[child:GetName()] then
+				ignore = true;
+			end
+			alreadyGathered[child:GetName()] = true;
 			if( not ignore ) then
 				if( not child:HasScript("OnClick") ) then
 					for _,subchild in ipairs({child:GetChildren()}) do
@@ -638,6 +648,14 @@ function MBB_HideButtons()
 end
 
 function MBB_OnUpdate(elapsed)
+	
+	if (not _rescanned and (GetTime() - _starttime) > 5) then
+			_rescanned = true;
+			MBB_GatherIcons();
+			MBB_SetButtonPosition();
+			return;	
+		end;
+	
 	if( MBB_DragFlag == 1 and MBB_Options.AttachToMinimap == 1 ) then
 		local xpos,ypos = GetCursorPosition();
 		local xmin,ymin,xm,ym = Minimap:GetLeft(), Minimap:GetBottom(), Minimap:GetRight(), Minimap:GetTop();


### PR DESCRIPTION
This fixes two issues:
- If all addons take less than 5 seconds to load, all minimap buttons were visible for a few seconds.
- If some addons take more than 5 seconds to load, their minimap button might not be "gathered".

`PLAYER_LOGIN` is called after all plugins were loaded, just before loading the world.
`PLAYER_ENTERING_WORLD` was also an option, but is called whenever changing zone, not just once.

I kept the 5-seconds timer, because some addons seem to load their minimap icon _after_ `PLAYER_LOGIN`, like `SuperAPI`.
I also added the `alreadyGathered` variable to keep track of which minimap icon was already gathered to not handle them twice.